### PR TITLE
Merged the changes for RUC LSM.

### DIFF
--- a/physics/GFS_rrtmgp_sw_pre.meta
+++ b/physics/GFS_rrtmgp_sw_pre.meta
@@ -56,6 +56,30 @@
   kind = kind_phys
   intent = in 
   optional = F
+[lsm]
+  standard_name = flag_for_land_surface_scheme
+  long_name = flag for land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_noahmp]
+  standard_name = flag_for_noahmp_land_surface_scheme
+  long_name = flag for NOAH MP land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_ruc]
+  standard_name = flag_for_ruc_land_surface_scheme
+  long_name = flag for RUC land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [lndp_var_list]
   standard_name = variables_to_be_perturbed_for_landperts
   long_name = variables to be perturbed for landperts
@@ -130,6 +154,15 @@
 [sncovr]
   standard_name = surface_snow_area_fraction_over_land
   long_name = surface snow area fraction
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[sncovr_ice]
+  standard_name = surface_snow_area_fraction_over_ice
+  long_name = surface snow area fraction over ice
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
@@ -413,6 +446,33 @@
   kind = kind_phys  
   intent = inout
   optional = F  
+[alb_ice]
+  standard_name =surface_snow_free_albedo_over_ice
+  long_name = surface snow-free albedo over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[alb_sno_ice]
+  standard_name =surface_snow_albedo_over_ice
+  long_name = surface snow albedo over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[sfalb_lnd_bck]
+  standard_name =surface_snow_free_albedo_over_land
+  long_name = surface snow-free albedo over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/GFS_surface_composites.meta
+++ b/physics/GFS_surface_composites.meta
@@ -15,9 +15,41 @@
   type = integer
   intent = in
   optional = F
+[flag_init]
+  standard_name = flag_for_first_time_step
+  long_name = flag signaling first time step for time integration loop
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [lkm]
   standard_name = flag_for_lake_surface_scheme
   long_name = flag for lake surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm]
+  standard_name = flag_for_land_surface_scheme
+  long_name = flag for land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_noahmp]
+  standard_name = flag_for_noahmp_land_surface_scheme
+  long_name = flag for NOAH MP land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_ruc]
+  standard_name = flag_for_ruc_land_surface_scheme
+  long_name = flag for RUC land surface model
   units = flag
   dimensions = ()
   type = integer
@@ -555,6 +587,24 @@
 [semis_ice]
   standard_name = surface_longwave_emissivity_over_ice_interstitial
   long_name = surface lw emissivity in fraction over ice (temporary use as interstitial)
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[emis_lnd]
+  standard_name = surface_longwave_emissivity_over_land
+  long_name = surface lw emissivity in fraction over land
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[emis_ice]
+  standard_name = surface_longwave_emissivity_over_ice
+  long_name = surface lw emissivity in fraction over ice
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real

--- a/physics/rrtmg_lw_pre.F90
+++ b/physics/rrtmg_lw_pre.F90
@@ -12,8 +12,9 @@
 !> \section arg_table_rrtmg_lw_pre_run Argument Table
 !! \htmlinclude rrtmg_lw_pre_run.html
 !!
-      subroutine rrtmg_lw_pre_run (im, lslwr, xlat, xlon, slmsk, snowd, sncovr,&
-        zorl, hprime, tsfg, tsfa, semis, emiss, errmsg, errflg)
+      subroutine rrtmg_lw_pre_run (im, lslwr, kdt, lsm, lsm_noahmp, lsm_ruc, vtype, &
+        xlat, xlon, slmsk, snowd, sncovr, sncovr_ice, zorl, hprime, tsfg, tsfa,     &
+        semis_lnd, semis_ice, semisbase, semis, errmsg, errflg)
     
       use machine,                   only: kind_phys
       use module_radiation_surface,  only: setemis
@@ -22,9 +23,13 @@
       
       integer,                              intent(in)  :: im
       logical,                              intent(in)  :: lslwr
-      real(kind=kind_phys), dimension(im),  intent(in)  :: xlat, xlon, slmsk,  &
-        snowd, sncovr, zorl, hprime, tsfg, tsfa
-      real(kind=kind_phys), dimension(:),   intent(in)  :: emiss 
+      integer, intent(in) :: kdt, lsm, lsm_noahmp, lsm_ruc
+
+      real(kind=kind_phys), dimension(im),  intent(in)  :: xlat, xlon, vtype, slmsk,&
+        snowd, sncovr, sncovr_ice, zorl, hprime, tsfg, tsfa
+      real(kind=kind_phys), dimension(:),   intent(in)  :: semis_lnd 
+      real(kind=kind_phys), dimension(:),   intent(in)  :: semis_ice 
+      real(kind=kind_phys), dimension(im),  intent(out) :: semisbase
       real(kind=kind_phys), dimension(im),  intent(out) :: semis
       character(len=*),                     intent(out) :: errmsg
       integer,                              intent(out) :: errflg
@@ -36,9 +41,11 @@
       if (lslwr) then
 !>  - Call module_radiation_surface::setemis(),to setup surface
 !! emissivity for LW radiation.
-        call setemis (xlon, xlat, slmsk, snowd, sncovr, zorl, tsfg, tsfa,      &
-                      hprime, emiss, im,                                       & !  ---  inputs
-                      semis)                              !  ---  outputs
+        call setemis (kdt, lsm, lsm_noahmp, lsm_ruc, vtype, xlon, xlat, slmsk, &
+                      snowd, sncovr, sncovr_ice, zorl, tsfg, tsfa,             &
+                      hprime, semis_lnd, semis_ice, im,                        & !  ---  inputs
+                      semisbase, semis)                                          !  ---  outputs
+
       endif
 
       end subroutine rrtmg_lw_pre_run

--- a/physics/rrtmg_lw_pre.meta
+++ b/physics/rrtmg_lw_pre.meta
@@ -23,6 +23,47 @@
   type = logical
   intent = in
   optional = F
+[kdt]
+  standard_name = index_of_time_step
+  long_name = current number of time steps
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm]
+  standard_name = flag_for_land_surface_scheme
+  long_name = flag for land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_noahmp]
+  standard_name = flag_for_noahmp_land_surface_scheme
+  long_name = flag for NOAH MP land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_ruc]
+  standard_name = flag_for_ruc_land_surface_scheme
+  long_name = flag for RUC land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[vtype]
+  standard_name = vegetation_type_classification_real
+  long_name = vegetation type for lsm
+  units = index
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [xlat]
   standard_name = latitude
   long_name = latitude
@@ -68,6 +109,15 @@
   kind = kind_phys
   intent = in
   optional = F
+[sncovr_ice]
+  standard_name = surface_snow_area_fraction_over_ice
+  long_name = surface snow area fraction over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [zorl]
   standard_name = surface_roughness_length
   long_name = surface roughness length
@@ -104,6 +154,33 @@
   kind = kind_phys
   intent = in
   optional = F
+[semis_lnd]
+  standard_name = surface_longwave_emissivity_over_land
+  long_name = surface lw emissivity in fraction over land
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[semis_ice]
+  standard_name = surface_longwave_emissivity_over_ice
+  long_name = surface lw emissivity in fraction over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[semisbase]
+  standard_name = baseline_surface_longwave_emissivity
+  long_name = baseline surface lw emissivity in fraction
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [semis]
   standard_name = surface_longwave_emissivity
   long_name = surface lw emissivity in fraction
@@ -112,15 +189,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
-[emiss]
-  standard_name = surface_emissivity_lsm
-  long_name = surface emissivity from lsm
-  units = frac
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
   optional = F
 [errmsg]
   standard_name = ccpp_error_message

--- a/physics/rrtmg_sw_pre.F90
+++ b/physics/rrtmg_sw_pre.F90
@@ -13,9 +13,10 @@
 !! \htmlinclude rrtmg_sw_pre_run.html
 !!
       subroutine rrtmg_sw_pre_run (im, lndp_type, n_var_lndp, lsswr, lndp_var_list, lndp_prt_list, tsfg, tsfa, coszen, &
-                                   alb1d, slmsk, snowd, sncovr, snoalb, zorl, hprime, alvsf, alnsf, alvwf,             &
-                                   alnwf, facsf, facwf, fice, tisfc, albdvis, albdnir, albivis, albinir,               &
-                                   sfalb, nday, idxday, sfcalb1, sfcalb2, sfcalb3, sfcalb4, errmsg, errflg)
+                                   lsm, lsm_noahmp, lsm_ruc, alb1d, slmsk, snowd, sncovr, sncovr_ice, snoalb, zorl,    &
+                                   hprime, alvsf, alnsf, alvwf, alnwf, facsf, facwf, fice, tisfc,                      &
+                                   albdvis, albdnir, albivis, albinir, sfalb, alb_ice, alb_sno_ice, sfalb_lnd_bck,     &
+                                   nday, idxday, sfcalb1, sfcalb2, sfcalb3, sfcalb4, errmsg, errflg)
 
       use machine,                   only: kind_phys
 
@@ -24,6 +25,7 @@
       implicit none
 
       integer,                              intent(in)    :: im, lndp_type, n_var_lndp
+      integer,                              intent(in)    :: lsm, lsm_noahmp, lsm_ruc
       character(len=3)    , dimension(:),   intent(in)    :: lndp_var_list
       logical,                              intent(in)    :: lsswr
       real(kind=kind_phys), dimension(:),   intent(in)    :: lndp_prt_list
@@ -35,10 +37,14 @@
                                                              alvsf, alnsf,     &
                                                              alvwf, alnwf,     &
                                                              facsf, facwf,     &
+                                                             sncovr_ice,       &
                                                              fice, tisfc
       real(kind=kind_phys), dimension(:),   intent(in)    :: albdvis, albdnir, & 
                                                              albivis, albinir
       real(kind=kind_phys), dimension(im),  intent(inout) :: sfalb
+      real(kind=kind_phys), dimension(im),  intent(inout) :: alb_ice,          &
+                                                             alb_sno_ice,      &
+                                                             sfalb_lnd_bck
       integer,                              intent(out)   :: nday
       integer, dimension(im),               intent(out)   :: idxday
       real(kind=kind_phys), dimension(im),  intent(out)   :: sfcalb1, sfcalb2, &
@@ -83,10 +89,11 @@
 !>  - Call module_radiation_surface::setalb() to setup surface albedo.
 !!  for SW radiation.
 
-        call setalb (slmsk, snowd, sncovr, snoalb, zorl,  coszen, tsfg, tsfa,  &  !  ---  inputs
-                     hprime, alvsf, alnsf, alvwf, alnwf, facsf, facwf, fice,   &
-                     tisfc, albdvis, albdnir, albivis, albinir,IM, alb1d,      &  !  mg, sfc-perts
-                     lndp_alb, sfcalb)                                            !  ---  outputs
+        call setalb (slmsk, lsm, lsm_noahmp, lsm_ruc, snowd, sncovr, sncovr_ice, snoalb,    &
+                     zorl, coszen, tsfg, tsfa, hprime, alvsf, alnsf, alvwf, alnwf,          &
+                     facsf, facwf, fice, tisfc, albdvis, albdnir, albivis, albinir,         &
+                     IM, alb1d, lndp_alb,                                                   &  !  mg, sfc-perts
+                     sfcalb, alb_ice, alb_sno_ice, sfalb_lnd_bck )                             !  ---  outputs
 
 
 !> -# Approximate mean surface albedo from vis- and nir-  diffuse values.

--- a/physics/rrtmg_sw_pre.meta
+++ b/physics/rrtmg_sw_pre.meta
@@ -84,6 +84,30 @@
   kind = kind_phys
   intent = in
   optional = F
+[lsm]
+  standard_name = flag_for_land_surface_scheme
+  long_name = flag for land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_noahmp]
+  standard_name = flag_for_noahmp_land_surface_scheme
+  long_name = flag for NOAH MP land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_ruc]
+  standard_name = flag_for_ruc_land_surface_scheme
+  long_name = flag for RUC land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [alb1d]
   standard_name = surface_albedo_perturbation
   long_name = surface albedo perturbation
@@ -114,6 +138,15 @@
 [sncovr]
   standard_name = surface_snow_area_fraction_over_land
   long_name = surface snow area fraction
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[sncovr_ice]
+  standard_name = surface_snow_area_fraction_over_ice
+  long_name = surface snow area fraction over ice
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
@@ -258,6 +291,33 @@
 [sfalb]
   standard_name = surface_diffused_shortwave_albedo
   long_name = mean surface diffused sw albedo
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[alb_ice]
+  standard_name =surface_snow_free_albedo_over_ice
+  long_name = surface snow-free albedo over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[alb_sno_ice]
+  standard_name =surface_snow_albedo_over_ice
+  long_name = surface snow albedo over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[sfalb_lnd_bck]
+  standard_name =surface_snow_free_albedo_over_land
+  long_name = surface snow-free albedo over ice
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real

--- a/physics/rrtmgp_lw_pre.meta
+++ b/physics/rrtmgp_lw_pre.meta
@@ -23,6 +23,47 @@
   type = integer
   intent = in
   optional = F
+[kdt]
+  standard_name = index_of_time_step
+  long_name = current number of time steps
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm]
+  standard_name = flag_for_land_surface_scheme
+  long_name = flag for land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_noahmp]
+  standard_name = flag_for_noahmp_land_surface_scheme
+  long_name = flag for NOAH MP land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_ruc]
+  standard_name = flag_for_ruc_land_surface_scheme
+  long_name = flag for RUC land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[vtype]
+  standard_name = vegetation_type_classification_real
+  long_name = vegetation type for lsm
+  units = index
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [xlon]
   standard_name = longitude
   long_name = longitude
@@ -77,6 +118,15 @@
   kind = kind_phys
   intent = in
   optional = F
+[sncovr_ice]
+  standard_name = surface_snow_area_fraction_over_ice
+  long_name = surface snow area fraction over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [tsfg]
   standard_name = surface_ground_temperature_for_radiation
   long_name = surface ground temperature for radiation
@@ -104,14 +154,32 @@
   kind = kind_phys
   intent = in
   optional = F
-[emiss]
-  standard_name = surface_emissivity_lsm
-  long_name = surface emissivity from lsm
+[semis_land]
+  standard_name = surface_longwave_emissivity_over_land
+  long_name = surface lw emissivity in fraction over land
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   intent = in
+  optional = F
+[semis_ice]
+  standard_name = surface_longwave_emissivity_over_ice
+  long_name = surface lw emissivity in fraction over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[semisbase]
+  standard_name = baseline_surface_longwave_emissivity
+  long_name = baseline surface lw emissivity in fraction
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
   optional = F
 [semis]
   standard_name = surface_longwave_emissivity

--- a/physics/sfc_noahmp_drv.meta
+++ b/physics/sfc_noahmp_drv.meta
@@ -1046,13 +1046,13 @@
   intent = out
   optional = F
 [emiss]
-  standard_name = surface_emissivity_lsm
-  long_name = surface emissivity from lsm
+  standard_name = surface_longwave_emissivity_over_land
+  long_name = surface lw emissivity in fraction over land
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
   optional = F
 [sncovr1]
   standard_name = surface_snow_area_fraction_over_land


### PR DESCRIPTION
Add to the code from @barlage to use albedo and emissivity from the RUC LSM.

1. In this version the RUC treatment of albedo differs from the Noah MP.
Further modifications in RUC LSM should include providing spectral components
of albedo and to add solar zenith angle dependence.
2. The emissivity treatment is generalized, and the same code works with both Noah MP and RUC LSMs.
3. These physics changes should be associated with the changes to GFS_typedefs.*.
4. The code is tested with both RUC and Noah MP LSMs.